### PR TITLE
fix: add missing score counter to 'next' button

### DIFF
--- a/public/pages/quiz.js
+++ b/public/pages/quiz.js
@@ -171,6 +171,10 @@ submitBtn.addEventListener('click',()=>{
 });
 
 next.addEventListener('click', ()=>{
+    const selectedOptionIndex=getSelectedOption();
+    if(selectedOptionIndex === quizData[currentQuiz].correct){
+        score++;
+    }
     currentQuiz++;
 
     if(currentQuiz<quizData.length){


### PR DESCRIPTION
The next button was missing to add the score count.
What is the difference between the 'Next' and the 'Submit' button? They seem to have the same implementation.

Thanks for letting me contribute!